### PR TITLE
Map Matter range to Tapo range for hue, saturation and brightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sudo apt install git gcc g++ libdbus-1-dev \
 
 Shallow clone the Connected Home IP project:
 ```bash
-git clone https://github.com/project-chip/connectedhomeip.git --depth=1
+git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=v1.0.0.2
 cd ~/connectedhomeip/
 scripts/checkout_submodules.py --shallow --platform linux
 ```

--- a/lighting.py
+++ b/lighting.py
@@ -31,6 +31,9 @@ import os
 
 from PyP100 import PyL530
 
+import struct
+import math
+
 dev = None
 dev_state = None
 switchedOn = None
@@ -103,6 +106,10 @@ def attributeChangeCallback(
     size: int,
     value: bytes,
 ):
+    
+    # convert bytes to little-endian unsigned integer
+    value = struct.unpack("<I", value)[0]
+
     if endpoint == 1:
         print("[callback] cluster={} attr={} value={}".format(
             clusterId, attributeId, list(value)))
@@ -119,7 +126,8 @@ def attributeChangeCallback(
         elif clusterId == 8 and attributeId == 0:
             if value:
                 print("[callback] level {}".format(value[0]))
-                set_level(value[0])
+                tapoLevel = math.trunc(value[0] * (100/254))
+                set_level(tapoLevel)
         # color
         elif clusterId == 768:
             if value:
@@ -127,11 +135,13 @@ def attributeChangeCallback(
                 # hue
                 if attributeId == 0:
                     print("[callback] color hue={}".format(value[0]))
-                    set_hue(value[0])
+                    tapoHue = math.trunc(value[0] * (359/254))
+                    set_hue(tapoHue)
                 # saturation
                 elif attributeId == 1:
                     print("[callback] color saturation={}".format(value[0]))
-                    set_saturation(value[0])
+                    tapoSaturation = math.trunc(value[0] * (100/254))
+                    set_saturation(tapoSaturation)
                 # temperature
                 elif attributeId == 7:
                     print("[callback] color temperature={}".format(value[0]))

--- a/lighting.py
+++ b/lighting.py
@@ -107,8 +107,6 @@ def attributeChangeCallback(
     value: bytes,
 ):
     
-    # convert bytes to little-endian unsigned integer
-    value = struct.unpack("<I", value)[0]
 
     if endpoint == 1:
         print("[callback] cluster={} attr={} value={}".format(
@@ -126,8 +124,7 @@ def attributeChangeCallback(
         elif clusterId == 8 and attributeId == 0:
             if value:
                 print("[callback] level {}".format(value[0]))
-                tapoLevel = math.trunc(value[0] * (100/254))
-                set_level(tapoLevel)
+                set_level(math.trunc(value * (100/254)))
         # color
         elif clusterId == 768:
             if value:
@@ -135,13 +132,11 @@ def attributeChangeCallback(
                 # hue
                 if attributeId == 0:
                     print("[callback] color hue={}".format(value[0]))
-                    tapoHue = math.trunc(value[0] * (359/254))
-                    set_hue(tapoHue)
+                    set_hue(math.trunc(value[0] * (359/254)))
                 # saturation
                 elif attributeId == 1:
                     print("[callback] color saturation={}".format(value[0]))
-                    tapoSaturation = math.trunc(value[0] * (100/254))
-                    set_saturation(tapoSaturation)
+                    set_saturation(math.trunc(value[0] * (100/254)))
                 # temperature
                 elif attributeId == 7:
                     print("[callback] color temperature={}".format(value[0]))

--- a/lighting.py
+++ b/lighting.py
@@ -63,7 +63,7 @@ def set_level(level: int):
     # The level setting is stored and resubmitted with every on/off command.
     # Skip when off or unknown, because setting level turns on the Tapo light.
     if switchedOn or switchedOn is None:
-        print("[tapo] {}: set brightness level".format(dev.ipAddress))
+        print("[tapo] {}: set brightness level {}".format(dev.ipAddress, level))
         dev.setBrightness(level)
 
 
@@ -120,8 +120,8 @@ def attributeChangeCallback(
         # level (brightness)
         elif clusterId == 8 and attributeId == 0:
             if value:
-                print("[callback] level {}".format(value[0]))
-                set_level(math.trunc(value * (100/254)))
+                print("[callback] level={}".format(value[0]))
+                set_level(math.trunc(value[0] * (100/254)))
         # color
         elif clusterId == 768:
             if value:

--- a/lighting.py
+++ b/lighting.py
@@ -31,7 +31,6 @@ import os
 
 from PyP100 import PyL530
 
-import struct
 import math
 
 dev = None
@@ -106,8 +105,6 @@ def attributeChangeCallback(
     size: int,
     value: bytes,
 ):
-    
-
     if endpoint == 1:
         print("[callback] cluster={} attr={} value={}".format(
             clusterId, attributeId, list(value)))

--- a/lighting.py
+++ b/lighting.py
@@ -105,6 +105,9 @@ def attributeChangeCallback(
     size: int,
     value: bytes,
 ):
+    if not value:
+        value = bytes([0])
+
     if endpoint == 1:
         print("[callback] cluster={} attr={} value={}".format(
             clusterId, attributeId, list(value)))


### PR DESCRIPTION
This PR implements a mapping of values from the Matter controller range to the Tapo bulbs range, affecting hue, saturation, and brightness/level. 

Here are the ranges:



| Parameter | Matter range | Tapo range |
|-----------|--------------|------------|
| Hue       | 0-254        | 0-359      |
| Saturation| 0-254        | 0-100      |
| Brightness/Level| [3-254](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/chip_tool_guide.md#step-7-control-application-data-model-clusters)   | 1-100      |




The following references are also used to validate and determine the above ranges:

- https://github.com/project-chip/connectedhomeip/tree/master/src/app/tests/suites
- https://docs.espressif.com/projects/esp-matter/en/main/esp32/developing.html
- https://github.com/project-chip/connectedhomeip/blob/b8389773bcb81b444b5ad62a68046af6f5ef4148/src/app/tests/suites/certification/Test_TC_CC_4_5.yaml#L82

### Testing
Hue:
```
# set default saturation
$ sudo chip-tool colorcontrol move-to-saturation 254 0 0 0 110 1
[tapo] 192.168.178.61: set color 359, 100

$ sudo chip-tool colorcontrol move-to-hue 0 1 0 0 0 110 1
[tapo] 192.168.178.61: set color 0, 100                                     <------------------- 0=>0

$ sudo chip-tool colorcontrol move-to-hue 1 1 0 0 0 110 1
# bridge logs
[tapo] 192.168.178.61: set color 1, 100                                     <------------------- 1=>1

$ sudo chip-tool colorcontrol move-to-hue 200 1 0 0 0 110 1
[tapo] 192.168.178.61: set color 282, 100                                <------------------- 200=>282

$ sudo chip-tool colorcontrol move-to-hue 254 1 0 0 0 110 1
[tapo] 192.168.178.61: set color 359, 100                                <------------------- 254=>359
```
Saturation:
```
# first set default hue
$ sudo chip-tool colorcontrol move-to-hue 254 1 0 0 0 110 1
[tapo] 192.168.178.61: set color 359, 78

$ sudo chip-tool colorcontrol move-to-saturation 0 0 0 0 110 1
[tapo] 192.168.178.61: set color 359, 0                                     <------------------- 0=>0

$ sudo chip-tool colorcontrol move-to-saturation 1 0 0 0 110 1
# bridge logs
[tapo] 192.168.178.61: set color 0, 0                                          <------------------- 1=>0

$ sudo chip-tool colorcontrol move-to-saturation 200 0 0 0 110 1
[tapo] 192.168.178.61: set color 359, 78                                     <------------------- 200=>78

$ sudo chip-tool colorcontrol move-to-saturation 254 0 0 0 110 1
[tapo] 192.168.178.61: set color 359, 100                                   <------------------- 254=>100
```
Brightness:
```
$ sudo chip-tool levelcontrol move-to-level 3 0 0 0 110 1
[tapo] 192.168.178.61: set brightness level 1                        <------------------- 3=>1
$ sudo chip-tool levelcontrol move-to-level 200 0 0 0 110 1
[tapo] 192.168.178.61: set brightness level 78                    <------------------- 200=>78

$ sudo chip-tool levelcontrol move-to-level 254 0 0 0 110 1
[tapo] 192.168.178.61: set brightness level 100                 <------------------- 254=>100
```

