### PR TITLE
Map Matter range to Tapo range for color temperature

### DIFF
--- a/lighting.py
+++ b/lighting.py
@@ -92,7 +92,7 @@ def set_saturation(saturation: int):
 def set_color_temperature(kelvin: int):
     global dev
 
-    print("[tapo] {}: set color temperature".format(dev.ipAddress))
+    print("[tapo] {}: set color temperature {}".format(dev.ipAddress, kelvin))
     dev.setColorTemp(kelvin)
 
 
@@ -139,8 +139,14 @@ def attributeChangeCallback(
                     set_saturation(math.trunc(value[0] * (100/254)))
                 # temperature
                 elif attributeId == 7:
-                    print("[callback] color temperature={}".format(value[0]))
-                    set_color_temperature(value[0])
+                    # extract and convert input of temperature from bytes 
+                    # to little-endian unsigned integer to accept wider input value
+                    value_list = value[:2]
+                    value_string = bytes(value_list)
+                    value = int.from_bytes(value_string, byteorder='little')
+
+                    print("[callback] color temperature={}".format(value))
+                    set_color_temperature(math.trunc(1000000/value))
 
         else:
             print("[callback] Error: unhandled cluster {} or attribute {}".format(

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
     after: [build-res]
     plugin: nil
     override-build: |   
-      git clone https://github.com/project-chip/connectedhomeip.git --depth=1 .
+      git clone https://github.com/project-chip/connectedhomeip.git --depth=1 --branch=v1.0.0.2 .
       scripts/checkout_submodules.py --shallow --platform linux
 
       # The project writes its data to /tmp. Snap does not allow bind mounting


### PR DESCRIPTION
This PR implements a mapping of values from the Matter controller range to the Tapo bulbs range, affecting color temperature.

Here is the range:

| Parameter | Matter range | Tapo range |
|-----------|--------------|------------|
| Color temperature       | 400-154 mireds       | 2500-6500 kelvins     |

Reference:
- https://en.wikipedia.org/wiki/Mired
### Testing
Color temperature:
```
$ sudo chip-tool colorcontrol move-to-color-temperature 400 0 0 0 110 1
[tapo] 192.168.178.61: set color temperature 2500                   <------------------- 400=>2500

$ sudo chip-tool colorcontrol move-to-color-temperature 250 0 0 0 110 1
[tapo] 192.168.178.61: set color temperature 4000                    <------------------- 250=>4000

$ sudo chip-tool colorcontrol move-to-color-temperature 154 0 0 0 110 1
[tapo] 192.168.178.61: set color temperature 6493                    <------------------- 154=>6493
```
